### PR TITLE
Add React Native bridge skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ Convert hexadecimal string of the image data to bytes ESC/POS command.
 - [paystory-de/thermal-printer-cordova-plugin : A Cordova / Ionic bridge](https://github.com/paystory-de/thermal-printer-cordova-plugin)
 - [asukiaaa/react-native-escpos-android : A React Native bridge](https://github.com/asukiaaa/react-native-escpos-android)
 - [android_bluetooth_printer : A Flutter bridge](https://pub.dev/packages/android_bluetooth_printer)
+- [react-native-escpos-bridge : Example React Native module](react-native-bridge)
 
 ## Contributing
 

--- a/react-native-bridge/README.md
+++ b/react-native-bridge/README.md
@@ -1,0 +1,18 @@
+# React Native Bridge
+
+Cette ébauche de module React Native expose une API minimale pour
+rechercher des imprimantes TCP/IP et envoyer un ticket au format texte
+à l'aide de la librairie Java existante.
+
+Le code Android se trouve dans `android/src` et est basé sur les
+`Native Modules` de React Native.
+
+**Fonctionnalités principales :**
+
+- `scanNetworkPrinters(baseIp, start, end)` : explore une plage d'adresses
+  et renvoie les hôtes répondant sur le port spécifié (par défaut 9100).
+- `print(ip, port, text)` : se connecte à une imprimante à l'adresse
+  donnée et envoie le texte à imprimer.
+
+Cette implémentation reste volontairement simple et pourra être
+complétée selon les besoins de l'application.

--- a/react-native-bridge/android/src/main/java/com/escpos/react/PosPrinterModule.java
+++ b/react-native-bridge/android/src/main/java/com/escpos/react/PosPrinterModule.java
@@ -1,0 +1,73 @@
+package com.escpos.react;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import com.dantsu.escposprinter.connection.tcp.TcpConnection;
+import com.dantsu.escposprinter.exceptions.EscPosConnectionException;
+import com.dantsu.escposprinter.exceptions.EscPosParserException;
+import com.dantsu.escposprinter.exceptions.EscPosEncodingException;
+import com.dantsu.escposprinter.exceptions.EscPosBarcodeException;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableArray;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PosPrinterModule extends ReactContextBaseJavaModule {
+    public PosPrinterModule(ReactApplicationContext context) {
+        super(context);
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "PosPrinter";
+    }
+
+    @ReactMethod
+    public void scanNetworkPrinters(String baseIp, int start, int end, Promise promise) {
+        new Thread(() -> {
+            List<String> found = new ArrayList<>();
+            for (int i = start; i <= end; i++) {
+                String ip = baseIp + i;
+                try (Socket socket = new Socket()) {
+                    socket.connect(new InetSocketAddress(ip, 9100), 150);
+                    found.add(ip);
+                } catch (IOException e) {
+                    // ignore
+                }
+            }
+            WritableArray array = Arguments.createArray();
+            for (String ip : found) {
+                array.pushString(ip);
+            }
+            promise.resolve(array);
+        }).start();
+    }
+
+    @ReactMethod
+    public void print(String ip, int port, String text, Promise promise) {
+        new Thread(() -> {
+            TcpConnection connection = new TcpConnection(ip, port);
+            try {
+                connection.connect();
+                connection.write(text.getBytes());
+                connection.send(0x0A);
+                connection.disconnect();
+                promise.resolve(null);
+            } catch (EscPosConnectionException | IOException e) {
+                Log.e("PosPrinter", "Print error", e);
+                promise.reject("PRINT_ERROR", e);
+            }
+        }).start();
+    }
+}

--- a/react-native-bridge/android/src/main/java/com/escpos/react/PosPrinterPackage.java
+++ b/react-native-bridge/android/src/main/java/com/escpos/react/PosPrinterPackage.java
@@ -1,0 +1,28 @@
+package com.escpos.react;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class PosPrinterPackage implements ReactPackage {
+    @NonNull
+    @Override
+    public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+        modules.add(new PosPrinterModule(reactContext));
+        return modules;
+    }
+
+    @NonNull
+    @Override
+    public List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+}

--- a/react-native-bridge/build.gradle
+++ b/react-native-bridge/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'com.android.library'
+}
+
+android {
+    compileSdkVersion 33
+
+    defaultConfig {
+        minSdkVersion 21
+        targetSdkVersion 33
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+}
+
+dependencies {
+    implementation project(':escposprinter')
+    implementation 'com.facebook.react:react-native:+' // From node_modules
+}

--- a/react-native-bridge/index.js
+++ b/react-native-bridge/index.js
@@ -1,0 +1,13 @@
+import { NativeModules } from 'react-native';
+
+const { PosPrinter } = NativeModules;
+
+export default {
+  scanNetworkPrinters(baseIp, start = 1, end = 254) {
+    return PosPrinter.scanNetworkPrinters(baseIp, start, end);
+  },
+
+  print(ip, port, text) {
+    return PosPrinter.print(ip, port, text);
+  },
+};

--- a/react-native-bridge/package.json
+++ b/react-native-bridge/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "react-native-escpos-bridge",
+  "version": "0.1.0",
+  "description": "React Native bridge for ESCPOS thermal printers",
+  "main": "index.js",
+  "keywords": ["escpos", "react-native", "printer"],
+  "author": "",
+  "license": "MIT"
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-include ':app', ':escposprinter'
+include ':app', ':escposprinter', ':react-native-bridge'
 rootProject.name='ThermalPrinter'


### PR DESCRIPTION
## Summary
- create `react-native-bridge` with android native module
- expose API in `index.js`
- reference example module in README
- register new module in settings.gradle

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a7351aa048333b79acfe4207a18f4